### PR TITLE
Refactor syntax methods to improve scope definitions

### DIFF
--- a/lib/guise.rb
+++ b/lib/guise.rb
@@ -1,14 +1,40 @@
+require "active_support/core_ext/string/inflections"
+require "active_support/core_ext/array/extract_options"
 require 'active_support/core_ext/module/attribute_accessors'
-require 'active_support/hash_with_indifferent_access'
 
 require 'guise/version'
+require "guise/errors"
+require "guise/registry"
+require "guise/options"
+require "guise/builders"
+require "guise/scopes"
 require 'guise/callbacks'
-require 'guise/syntax'
-require 'guise/introspection'
+require "guise/introspection"
+require "guise/syntax"
 
 module Guise
   mattr_reader :registry
-  @@registry = HashWithIndifferentAccess.new
+  @@registry = Registry.new
+
+  DEFAULT_ASSOCIATION_NAME = "guises"
+  DEFAULT_ATTRIBUTE_NAME = "value"
+
+  def self.register_source(source_class, *guises)
+    options = Options.new(source_class, *guises)
+    registry[source_class.name] = options
+
+    HasGuisesBuilder.new(options).build!
+  end
+
+  def self.register_association(association_class, source_class_name, association_options)
+    options = registry[source_class_name]
+
+    GuiseForBuilder.new(
+      association_class,
+      options,
+      association_options
+    ).build!
+  end
 end
 
 if defined?(ActiveRecord)

--- a/lib/guise/builders.rb
+++ b/lib/guise/builders.rb
@@ -1,0 +1,144 @@
+require "guise/scopes"
+
+module Guise
+  # @api private
+  class HasGuisesBuilder
+    def initialize(options)
+      @options = options
+    end
+
+    def build!
+      set_guise_options!
+      define_association!
+      define_scopes!
+
+      if options.association_options != DEFAULT_ASSOCIATION_NAME
+        define_association_aliases!
+      end
+
+      define_introspection_aliases!
+    end
+
+    private
+
+    attr_reader :options
+
+    def set_guise_options!
+      source_class.class_attribute :guise_options, instance_writer: false
+      source_class.guise_options = options
+    end
+
+    def define_association!
+      source_class.has_many(
+        options.association_name,
+        options.association_options
+      )
+    end
+
+    def define_scopes!
+      options.values.each do |value|
+        method_name = value.underscore
+        scope_name = method_name.pluralize
+
+        source_class.scope scope_name, HasGuisesScope.new(value, options)
+
+        source_class.class_eval <<-METHOD
+          def #{method_name}?
+            has_guise?(#{value})
+          end
+        METHOD
+      end
+    end
+
+    def define_association_aliases!
+      source_class.class_eval <<-ASSOCIATION_ALIASES
+        alias_method :guises, :#{association_name}
+        alias_method :guises=, :#{association_name}=
+        alias_method :guise_ids, :#{association_name_singular}_ids
+        alias_method :guise_ids=, :#{association_name_singular}_ids=
+      ASSOCIATION_ALIASES
+    end
+
+    def define_introspection_aliases!
+      source_class.class_eval <<-INTROSPECTION_ALIASES
+        alias_method :has_#{association_name_singular}?, :has_guise?
+        alias_method :has_#{association_name}?, :has_guises?
+        alias_method :has_any_#{association_name}?, :has_any_guises?
+      INTROSPECTION_ALIASES
+    end
+
+    def source_class
+      options.source_class
+    end
+
+    def association_name
+      options.association_name
+    end
+
+    def association_name_singular
+      options.association_name_singular
+    end
+  end
+
+  # @api private
+  class GuiseForBuilder
+    def initialize(association_class, options, association_options)
+      @association_class = association_class
+      @options = options
+      @association_options = association_options.reverse_merge!(
+        @options.default_association_options
+      )
+      @define_validations = !@association_options.delete(:validate)
+    end
+
+    def build!
+      update_guise_options!
+      define_association!
+      define_scopes!
+
+      if define_validations?
+        define_validations!
+      end
+    end
+
+    private
+
+    attr_reader(
+      :association_class,
+      :options,
+      :association_options,
+      :define_validations
+    )
+
+    alias :define_validations? :define_validations
+
+    def update_guise_options!
+      options.association_class = association_class
+    end
+
+    def define_association!
+      association_class.belongs_to(
+        options.source_association_name,
+        association_options
+      )
+    end
+
+    def define_scopes!
+      options.values.each do |value|
+        association_class.scope(
+          value.underscore.pluralize,
+          GuiseForScope.new(value, options)
+        )
+      end
+    end
+
+    def define_validations!
+      association_class.validates(
+        options.attribute,
+        uniqueness: { scope: options.association_options[:foreign_key] },
+        presence: true,
+        inclusion: { in: options.values }
+      )
+    end
+  end
+end

--- a/lib/guise/errors.rb
+++ b/lib/guise/errors.rb
@@ -1,0 +1,32 @@
+module Guise
+  class DefinitionNotFound < StandardError
+    def initialize(name)
+      @name = name
+    end
+
+    def message
+      "no guises defined for #{@name.inspect}"
+    end
+  end
+
+  class DuplicateDefinition < StandardError
+    def initialize(name)
+      @name = name
+    end
+
+    def message
+      "guise definition for #{@name.inspect} already exists"
+    end
+  end
+
+  class InvalidGuiseValue < ArgumentError
+    def initialize(guise_value, klass)
+      @guise_value = guise_value
+      @klass = klass
+    end
+
+    def message
+      "`#{guise_value}' is not a defined guise value for #{klass}"
+    end
+  end
+end

--- a/lib/guise/introspection.rb
+++ b/lib/guise/introspection.rb
@@ -12,11 +12,14 @@ module Guise
     def has_guise?(value)
       value = value.to_s.classify
 
-      unless guise_options[:names].any? { |name| name == value }
+      unless guise_options.values.include?(value)
         raise ArgumentError, "no such guise #{value}"
       end
 
-      guises.any? { |guise| !guise.marked_for_destruction? && guise[guise_options[:attribute]] == value }
+      association(guise_options.association_name).reader.any? do |record|
+        !record.marked_for_destruction? &&
+          record[guise_options.attribute] == value
+      end
     end
 
     # Checks if the record has any `guise` records with identified by any of
@@ -35,12 +38,6 @@ module Guise
     # @return [true, false]
     def has_guises?(*values)
       values.all? { |value| has_guise?(value) }
-    end
-
-    private
-
-    def guise_options
-      Guise.registry[self.class.table_name.classify]
     end
   end
 end

--- a/lib/guise/options.rb
+++ b/lib/guise/options.rb
@@ -1,0 +1,75 @@
+module Guise
+  # @api private
+  class Options
+    attr_reader(
+      :source_class,
+      :values,
+      :association_name,
+      :association_name_singular,
+      :attribute,
+      :association_options,
+      :scopes
+    )
+
+    attr_writer :association_class
+
+    def initialize(source_class, *values)
+      options = values.extract_options!
+
+      if values.empty?
+        raise ArgumentError, "must specify values in `has_guises`"
+      end
+
+      @source_class = source_class
+      @values = values.map(&:to_s).to_set
+      @association_name =
+        options.delete(:association) || DEFAULT_ASSOCIATION_NAME
+      @association_name_singular = @association_name.to_s.singularize
+      @attribute = options.delete(:attribute) || DEFAULT_ATTRIBUTE_NAME
+      @association_options = options.reverse_merge!(default_association_options)
+
+      @scopes = values.inject(HashWithIndifferentAccess.new) do |all, value|
+        all.merge!(value => {})
+      end
+      @scopes.freeze
+    end
+
+    def scope(guise_value, scope_type)
+      value_scopes = @scopes.fetch(guise_value) do
+        raise InvalidGuiseValue.new(guise_value, source_class)
+      end
+
+      value_scopes.fetch(scope_type) do
+        raise ArgumentError, "`#{scope_type}' is not a valid type of scope"
+      end
+    end
+
+    def register_scope(guise_value, scope)
+      value_scopes = @scopes.fetch(guise_value) do
+        raise InvalidGuiseValue.new(guise_value, source_class)
+      end
+
+      if value_scopes.key?(scope.type)
+        raise "`#{scope.type}' scope already defined for #{source_class}"
+      end
+
+      value_scopes[scope.type] = scope
+    end
+
+    def association_class
+      if defined?(@association_class)
+        @association_class
+      else
+        raise "`guise_for` was not called on the association class"
+      end
+    end
+
+    def source_association_name
+      source_class.model_name.singular.to_sym
+    end
+
+    def default_association_options
+      { foreign_key: "#{source_association_name}_id" }
+    end
+  end
+end

--- a/lib/guise/registry.rb
+++ b/lib/guise/registry.rb
@@ -1,0 +1,23 @@
+require "active_support/hash_with_indifferent_access"
+
+module Guise
+  class Registry
+    def initialize
+      @registry = HashWithIndifferentAccess.new
+    end
+
+    def [](name)
+      @registry.fetch(name) do
+        raise DefinitionNotFound.new(name)
+      end
+    end
+
+    def []=(name, definition)
+      if @registry.key?(name)
+        raise DuplicateDefinition.new(name)
+      end
+
+      @registry[name] = definition
+    end
+  end
+end

--- a/lib/guise/scopes.rb
+++ b/lib/guise/scopes.rb
@@ -1,0 +1,69 @@
+module Guise
+  # @api private
+  class Scope
+    def initialize(value, options)
+      @value = value
+      @options = options
+
+      @options.register_scope(value, self)
+    end
+
+    private
+
+    attr_reader :value, :options
+  end
+
+  # @api private
+  class HasGuisesScope < Scope
+    def call
+      relation.create_with(association_name => [association_relation.new])
+    end
+
+    def type
+      :has_guises
+    end
+
+    private
+
+    def relation
+      source_class.
+        select(source_class.arel_table[Arel.star]).
+        joins(association_name).
+        merge(association_relation)
+    end
+
+    def source_class
+      options.source_class
+    end
+
+    def association_name
+      options.association_name
+    end
+
+    def association_relation
+      options.scope(value, :guise_for).call
+    end
+  end
+
+  # @api private
+  class GuiseOfScope < HasGuisesScope
+    def call
+      relation
+    end
+
+    def type
+      :guise_of
+    end
+  end
+
+  # @api private
+  class GuiseForScope < Scope
+    def call
+      options.association_class.where(options.attribute => value)
+    end
+
+    def type
+      :guise_for
+    end
+  end
+end

--- a/lib/guise/syntax.rb
+++ b/lib/guise/syntax.rb
@@ -38,45 +38,10 @@ module Guise
     #   @option options [Symbol] :attribute name of the association's column
     #     where the value of which guise is being represented is stored. This
     #     option is required.
-    #   @option options [Symbol] :table_name name of the association's table
     def has_guises(*guises)
       include Introspection
 
-      options = guises.last.is_a?(Hash) ? guises.pop : {}
-
-      guises      = guises.map(&:to_s)
-      association = options.fetch(:association)
-      attribute   = options.fetch(:attribute)
-      join_table  = options[:table_name] || association
-
-      Guise.registry[self.name] = {
-        names: guises,
-        association: association,
-        attribute: attribute
-      }
-
-      guises.each do |guise|
-        method_name = guise.underscore
-        scope method_name.pluralize, -> { select("#{self.table_name}.*").joins(association).where(join_table => { attribute => guise }) }
-
-        define_method "#{method_name}?" do
-          has_guise?(guise)
-        end
-      end
-
-      has_many association, options.except(:association, :attribute, :table_name)
-
-      if association != :guises
-        association_singular = association.to_s.singularize
-
-        alias_method :guises, association
-        alias_method :guises=, "#{association}="
-        alias_method :guise_ids, "#{association_singular}_ids"
-        alias_method :guise_ids=, "#{association_singular}_ids="
-        alias_method "has_#{association_singular}?", :has_guise?
-        alias_method "has_#{association}?", :has_guises?
-        alias_method "has_any_#{association}?", :has_any_guises?
-      end
+      Guise.register_source(self, *guises)
     end
 
     # Specifies that the model is a subclass of a model configured with
@@ -114,18 +79,13 @@ module Guise
     # end
     # ```
     #
-    # @param [String, Symbol] class_name name of the superclass configured with
-    #   {#has_guises}.
-    def guise_of(class_name)
-      options = Guise.registry[class_name]
+    # @param [String, Symbol] source_class_name name of the superclass
+    #   configured with {#has_guises}.
+    def guise_of(source_class_name)
+      options = Guise.registry[source_class_name]
 
-      if options.nil?
-        raise ArgumentError, "no guises defined on #{class_name}"
-      end
-
-      default_scope -> { send(model_name.plural) }
-
-      after_initialize SourceCallback.new(self.name, options[:attribute])
+      default_scope GuiseOfScope.new(name, options)
+      after_initialize SourceCallback.new(name, options.attribute)
     end
 
     # Configures the other end of the association defined by {#has_guises}.
@@ -161,39 +121,20 @@ module Guise
     # end
     # ```
     #
-    # @param [Symbol, String] class_name name of the class configured with
-    #   {#has_guises}
+    # @param [Symbol, String] source_class_name name of the class configured
+    #   with {#has_guises}
     # @param [Hash] options options to configure the `belongs_to` association.
     # @option options [false] :validate specify `false` to skip
     #   validations for the `:attribute` specified in {#has_guises}
     # @option options [Symbol] :foreign_key foreign key used to build the
     #   association.
-    def guise_for(class_name, options = {})
-      guise_options = Guise.registry[class_name]
-
-      if guise_options.nil?
-        raise ArgumentError, "no guises defined on #{class_name}"
-      end
-
-      association = class_name.to_s.underscore.to_sym
-      guises      = guise_options[:names]
-      attribute   = guise_options[:attribute]
-      foreign_key = options[:foreign_key] || "#{class_name.to_s.underscore}_id"
-
-      belongs_to association, options.except(:validate)
-
-      guises.each do |guise|
-        scope guise.underscore.pluralize, -> { where(attribute => guise) }
-      end
-
-      if options[:validate] != false
-        validates attribute, uniqueness: { scope: foreign_key }, presence: true, inclusion: { in: guises }
-      end
+    def guise_for(source_class_name, options = {})
+      Guise.register_association(self, source_class_name, options)
     end
 
     # Specifies that the model is a subclass of a model configured with
     # {#guise_for} specified by `class_name`. The name of the calling class must
-    # be `<guise_value|parent_class_name>`.
+    # be `<value|parent_class_name>`.
     #
     # Given the following configuration with `guise_for`:
     #
@@ -223,25 +164,14 @@ module Guise
     # end
     # ```
     #
-    # @param [Symbol, String] class_name name of the superclass configured with
-    #   {#guise_for}.
-    def scoped_guise_for(class_name)
-      guise_options = Guise.registry[class_name]
+    # @param [Symbol, String] association_class_name name of the superclass
+    #   configured with {#guise_for}.
+    def scoped_guise_for(association_class_name)
+      options = Guise.registry[association_class_name]
+      value = name.chomp(options.association_class.name)
 
-      if guise_options.nil?
-        raise ArgumentError, "no guises defined on #{class_name}"
-      end
-
-      attribute = guise_options[:attribute]
-      parent_name = table_name.classify
-
-      value = guise_options[:names].detect do |guise|
-        guise == model_name.to_s.chomp(parent_name)
-      end
-
-      default_scope -> { where(attribute => value) }
-
-      after_initialize AssociationCallback.new(value, attribute)
+      default_scope options.scope(value, :guise_for)
+      after_initialize AssociationCallback.new(value, options.attribute)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,7 +57,14 @@ class TechnicianUserRole < UserRole
 end
 
 class Person < ActiveRecord::Base
-  has_guises :Admin, :Manager, :Reviewer, association: :permissions, attribute: :privilege, foreign_key: :employee_id, table_name: :privileges
+  has_guises(
+    :Admin,
+    :Manager,
+    :Reviewer,
+    association: :permissions,
+    attribute: :privilege,
+    foreign_key: :employee_id
+  )
 end
 
 class Permission < ActiveRecord::Base


### PR DESCRIPTION
Introduce objects to better handle association / method definitions and
sharing of scopes:

* `Guise::Registry` Reduces duplication of raising an error if no
  definitions are found configuring the association and subclasses.
* `Guise::Options` allows for better customization, sharing and
  manipulation of options initially passed to `has_guises`. This will be
  used as the canonical source of information about any defintion
  instead of re-calculating properties on-demand.
* `Guise::Scope` and its subclasses defer building
  `ActiveRecord::Relation` scopes to runtime when both `guise_of` and
  `has_guises` have been called.
* `Guise::SourceBuilder` and `Guise::AssociationBuilder` break up the
  different tasks required for setting up the primary source and
  association classes.

Fixes #6 and #5.